### PR TITLE
Delete .gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,3 +1,0 @@
-[user]
-	email = amit.wifi@gmail.com
-	name = Amit Goldenberg


### PR DESCRIPTION
I had to run into this issue-
when installing the dotfiles, I accidentally had .gitconfig overwrite my local .gitconfig file, which lead to _[this invalid commit](https://github.com/vanillyn/vanillyn.github.io/commit/0d233d75e66db3067d50e83a00ad1c6bd606cd2f)_ due to using git over ssh.